### PR TITLE
Do not load our theme.js on ReadTheDocs (SHOOP-2433)

### DIFF
--- a/sphinx_shoop_theme/layout.html
+++ b/sphinx_shoop_theme/layout.html
@@ -174,7 +174,10 @@
 
   {% endif %}
 
-  <script type="text/javascript" src="{{ pathto('_static/js/theme.js', 1) }}"></script>
+  {# RTD hosts this file, so just load on non RTD builds #}
+  {% if not READTHEDOCS %}
+    <script type="text/javascript" src="{{ pathto('_static/js/theme.js', 1) }}"></script>
+  {% endif %}
 
   {# STICKY NAVIGATION #}
   {% if theme_sticky_navigation %}


### PR DESCRIPTION
ReadTheDocs forces loading of its own JavaScript which implements these
same functions.  This cases e.g. toggling of "shift-up" class for the
version selection box to happen twice effectively making it never really
toggle the class and box never appears.

Since we cannot prevent "readthedocs-doc-embed.js" being embedded and
loaded on ReadTheDocs, let's not embed our version then.
